### PR TITLE
✨ Support use as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: auto-optional
+    name: auto-optional
+    description: Adds the Optional type-hint to arguments where the default value is None
+    entry: auto-optional
+    language: python
+    types: [python]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ Install with `pip install auto-optional`.
 ## Run
 After installing you can run auto-optional using `auto-optional [path]` (path is an optional argument).
 
+## pre-commit
+
+You can run auto-optional via [pre-commit](https://pre-commit.com/).
+Add the following text to your repositories `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+- repo: https://github.com/luttik/auto-optional
+  rev: v0.2.0 # The version of auto-optional to use
+  hooks:
+  - id: auto-optional
+```
+
 ## Things of note
 
 ### Things that are handled well

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,19 @@ Install with `pip install auto-optional`.
 ## Run
 After installing you can run auto-optional using `auto-optional [path]` (path is an optional argument).
 
+## pre-commit
+
+You can run auto-optional via [pre-commit](https://pre-commit.com/).
+Add the following text to your repositories `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+- repo: https://github.com/luttik/auto-optional
+  rev: v0.2.0 # The version of auto-optional to use
+  hooks:
+  - id: auto-optional
+```
+
 ## Things of note
 
 ### Things that are handled well


### PR DESCRIPTION
Hi,

Thank you for implementing this useful tool.
I'd like to use auto-optional in my projects automatically by adding it to my pre-commit pipeline.

This PR adds a config to be able to use it in [pre-commit](https://pre-commit.com/).
I also added a section to the README describing how to use auto-optional with pre-commit.