### PR TITLE
allowing multiple path arguments, at least one argument has to be given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .venv/
 .pytest_cache/
+__pycache__/
 .idea/
 dist/
 /.coverage
+

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,6 @@
     name: auto-optional
     description: Adds the Optional type-hint to arguments where the default value is None
     entry: auto-optional
+    require_serial: True
     language: python
     types: [python]

--- a/src/auto_optional/main.py
+++ b/src/auto_optional/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 
 import typer
 
@@ -8,8 +9,10 @@ app = typer.Typer()
 
 
 @app.command()
-def main(path: Path = typer.Argument(".")) -> None:
-    converted_files = convert_path(path)
+def main(path: List[Path] = typer.Argument(None)) -> None:
+    if not path:
+        path = [Path(".")]
+    converted_files = sum(convert_path(p) for p in path)
     if converted_files:
         typer.echo(f"{converted_files} were fixed.")
     else:

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -2,16 +2,22 @@ from abc import ABC
 from pathlib import Path
 from typing import List, Union
 
+import py
 import pytest
 from pydantic import BaseModel
+from typer.testing import CliRunner
 from yaml import load
 
 from auto_optional.file_handling import convert_file
+from auto_optional.main import app
 
 try:
     from yaml import CLoader as YamlLoader
 except ImportError:
     from yaml import YamlLoader  # type: ignore
+
+
+runner = CliRunner()
 
 
 class BaseTestConfig(BaseModel, ABC):
@@ -44,6 +50,39 @@ def get_singe_file_tests() -> List:
 SINGLE_FILE_TESTS = get_singe_file_tests()
 
 
+def prepare_file(
+    test_config: Union[BeforeAndAfterTest, UnchangedTest], tmpdir: Path
+) -> Path:
+    if isinstance(test_config, BeforeAndAfterTest):
+        code = test_config.before
+    elif isinstance(test_config, UnchangedTest):
+        code = test_config.unchanged
+    else:
+        raise NotImplementedError(
+            f"tests of type {type(test_config)} are not yet supported"
+        )
+
+    code_path = tmpdir / f"{hash(code)}.py"
+    code_path.write_text(code)
+    return code_path
+
+
+def assert_code_processed_correctly(
+    test_config: Union[BeforeAndAfterTest, UnchangedTest],
+    path: Path,
+) -> None:
+    if isinstance(test_config, BeforeAndAfterTest):
+        code = test_config.after
+    elif isinstance(test_config, UnchangedTest):
+        code = test_config.unchanged
+    else:
+        raise NotImplementedError(
+            f"tests of type {type(test_config)} are not yet supported"
+        )
+
+    assert path.read_text() == code
+
+
 @pytest.mark.parametrize(
     "test_config",
     SINGLE_FILE_TESTS,
@@ -60,3 +99,42 @@ def test_single_files_from_yaml(
         raise NotImplementedError(
             f"tests of type {type(test_config)} are not yet supported"
         )
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    SINGLE_FILE_TESTS,
+    ids=[test.name for test in SINGLE_FILE_TESTS],
+)
+def test_cli_single_files_from_yaml(
+    test_config: Union[BeforeAndAfterTest, UnchangedTest], tmpdir: py.path.local
+) -> None:
+    single_code_file_path = prepare_file(test_config, Path(tmpdir))
+    runner.invoke(app, [str(single_code_file_path)])
+    assert_code_processed_correctly(test_config, single_code_file_path)
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    SINGLE_FILE_TESTS,
+    ids=[test.name for test in SINGLE_FILE_TESTS],
+)
+def test_cli_no_file_should_use_current_dir(
+    test_config: Union[BeforeAndAfterTest, UnchangedTest], tmpdir: py.path.local
+) -> None:
+    tmpdir.chdir()
+    single_code_file_path = prepare_file(test_config, Path(tmpdir))
+    runner.invoke(app)
+    assert_code_processed_correctly(test_config, single_code_file_path)
+
+
+def test_cli_multi_file(tmpdir: py.path.local) -> None:
+    test_with_paths = [
+        (test_config, prepare_file(test_config, Path(tmpdir)))
+        for test_config in SINGLE_FILE_TESTS
+    ]
+
+    runner.invoke(app, [str(path) for _, path in test_with_paths])
+
+    for test_config, path in test_with_paths:
+        assert_code_processed_correctly(test_config, path)


### PR DESCRIPTION
Fixes https://github.com/Luttik/auto-optional/issues/14

`require_serial` doesn't work on its own. One has to allow multiple arguments. But when multiple arguments are allowed, one cannot use default values. Calling `auto-optional` without arguments leads to an error. But when using `typer.Option` instead of `typer.Argument` one has to use parameter names.

So the only solution I have now is allowing multiple arguments with no defaults.