### PR TITLE
🔥 Fix import added too early

### DIFF
--- a/src/auto_optional/code_processing.py
+++ b/src/auto_optional/code_processing.py
@@ -116,8 +116,35 @@ class AutoOptionalTransformer(cst.CSTTransformer):
                     )
                 ]
             )
+            insert_at = 0
+            for index, body_part in enumerate(updated_node.body):
+                if (
+                    isinstance(body_part, cst.SimpleStatementLine)
+                    and len(body_part.children) > 0
+                    and (
+                        (  # module level docstring
+                            index == 0
+                            and m.matches(
+                                body_part.children[0], m.Expr(m.SimpleString())
+                            )
+                        )
+                        or m.matches(  # future import
+                            body_part.children[0],
+                            m.ImportFrom(module=m.Name("__future__")),
+                        )
+                    )
+                ):
+                    # module docstring
+                    insert_at += 1
+                    continue
+                if index > 1:
+                    break
             return updated_node.with_changes(
-                body=[import_statement, *updated_node.body]
+                body=[
+                    *updated_node.body[:insert_at],
+                    import_statement,
+                    *updated_node.body[insert_at:],
+                ]
             )
         return updated_node
 

--- a/src/auto_optional/code_processing.py
+++ b/src/auto_optional/code_processing.py
@@ -99,54 +99,56 @@ class AutoOptionalTransformer(cst.CSTTransformer):
 
         Is only used to add the ``typing.Optional`` import statement when missing.
         """
-        if self.optional_import_checker.import_names and self.optional_import_needed:
-            import_statement = cst.SimpleStatementLine(
-                body=[
-                    cst.ImportFrom(
-                        module=cst.Name(
-                            value="typing",
-                        ),
-                        names=[
-                            cst.ImportAlias(
-                                name=cst.Name(
-                                    value="Optional",
-                                ),
+        if (
+            not self.optional_import_checker.import_names
+            or not self.optional_import_needed
+        ):
+            return updated_node
+
+        import_statement = cst.SimpleStatementLine(
+            body=[
+                cst.ImportFrom(
+                    module=cst.Name(
+                        value="typing",
+                    ),
+                    names=[
+                        cst.ImportAlias(
+                            name=cst.Name(
+                                value="Optional",
                             ),
-                        ],
+                        ),
+                    ],
+                )
+            ]
+        )
+        insert_at = 0
+        for index, body_part in enumerate(updated_node.body):
+            if (
+                isinstance(body_part, cst.SimpleStatementLine)
+                and len(body_part.children) > 0
+                and (
+                    (  # module level docstring
+                        index == 0
+                        and m.matches(body_part.children[0], m.Expr(m.SimpleString()))
                     )
-                ]
-            )
-            insert_at = 0
-            for index, body_part in enumerate(updated_node.body):
-                if (
-                    isinstance(body_part, cst.SimpleStatementLine)
-                    and len(body_part.children) > 0
-                    and (
-                        (  # module level docstring
-                            index == 0
-                            and m.matches(
-                                body_part.children[0], m.Expr(m.SimpleString())
-                            )
-                        )
-                        or m.matches(  # future import
-                            body_part.children[0],
-                            m.ImportFrom(module=m.Name("__future__")),
-                        )
+                    or m.matches(  # future import
+                        body_part.children[0],
+                        m.ImportFrom(module=m.Name("__future__")),
                     )
-                ):
-                    # module docstring
-                    insert_at += 1
-                    continue
-                if index > 1:
-                    break
-            return updated_node.with_changes(
-                body=[
-                    *updated_node.body[:insert_at],
-                    import_statement,
-                    *updated_node.body[insert_at:],
-                ]
-            )
-        return updated_node
+                )
+            ):
+                # module docstring
+                insert_at += 1
+                continue
+            if index > 1:
+                break
+        return updated_node.with_changes(
+            body=[
+                *updated_node.body[:insert_at],
+                import_statement,
+                *updated_node.body[insert_at:],
+            ]
+        )
 
     def __check_if__union_none(self, annotation: cst.BaseExpression) -> bool:
         #  Return if it is a Union[..., None, ...] statement

--- a/test/simple-tests.yaml
+++ b/test/simple-tests.yaml
@@ -94,6 +94,41 @@ tests:
       def bla(foo: Optional[str] = None):
           ...
 
+  - name: test_with_module_docstring
+    before: |
+      """Something"""
+      def f(s: str = None):
+          ...
+    after: |
+      """Something"""
+      from typing import Optional
+      def f(s: Optional[str] = None):
+          ...
+
+  - name: test_with_future_import
+    before: |
+      from __future__ import annotations
+      def f(s: str = None):
+          ...
+    after: |
+      from __future__ import annotations
+      from typing import Optional
+      def f(s: Optional[str] = None):
+          ...
+
+  - name: test_docstring_with_future_import
+    before: |
+      """Something"""
+      from __future__ import annotations
+      def f(s: str = None):
+          ...
+    after: |
+      """Something"""
+      from __future__ import annotations
+      from typing import Optional
+      def f(s: Optional[str] = None):
+          ...
+
   - name: test_nochange_typing_as_import
     unchanged: |
       import typing as t


### PR DESCRIPTION
In case of module with a docstring or with a `__future__` import, the `Optional` import should be added after.